### PR TITLE
tweaks needed to get this running locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,8 @@ Thumbs.db
 **/pnpm-lock.yaml
 
 # === SSE cache, custom stuff ===
-**/session-storage.ts
+# unsure what this was
+# **/session-storage.ts
 
 # === Coverage ===
 **/coverage/

--- a/api-server/prisma/schema.prisma
+++ b/api-server/prisma/schema.prisma
@@ -8,14 +8,14 @@ generator client {
   provider = "prisma-client-js"
 }
 
-datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
-}
 // datasource db {
-//   provider = "sqlite"
-//   url      = "file:./dev.db"
+//   provider = "postgresql"
+//   url      = env("DATABASE_URL")
 // }
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
 
 model User {
   id    String   @id @default(cuid())

--- a/basic-chat-client/package.json
+++ b/basic-chat-client/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^1.2.9",
     "@ai-sdk/openai": "^1.3.9",
     "@ai-sdk/react": "^1.2.8",
     "@radix-ui/react-avatar": "^1.1.4",

--- a/basic-chat-client/src/app/api/chat/route.ts
+++ b/basic-chat-client/src/app/api/chat/route.ts
@@ -1,6 +1,6 @@
 import { getTokenSet } from "@/app/auth/get-tokenset";
 import { mcp_server_installer } from "@/app/tools/mcp-server-helper";
-import { openai } from "@ai-sdk/openai";
+import { anthropic } from "@ai-sdk/anthropic";
 import { experimental_createMCPClient, streamText } from "ai";
 
 // Allow streaming responses up to 30 seconds
@@ -42,7 +42,7 @@ export async function POST(req: Request) {
   }
 
   const result = streamText({
-    model: openai("gpt-4o"),
+    model: anthropic("claude-3-7-sonnet-latest"),
     messages,
     maxSteps: 10,
     toolCallStreaming: true,

--- a/basic-chat-client/src/app/tools/protected-metadata-discovery.ts
+++ b/basic-chat-client/src/app/tools/protected-metadata-discovery.ts
@@ -122,7 +122,9 @@ async function discoverProtectedResourceMetadata(
   const resourceMetadata = await fetchMetadata(metadataUrl);
 
   if (resourceMetadata.resource !== resourceUrl) {
-    throw new Error("Resource does not match metadata in origin");
+    throw new Error(
+      `Resource does not match metadata in origin, ${resourceMetadata.resource} != ${resourceUrl}`,
+    );
   }
 
   return resourceMetadata;

--- a/mcp-server/Readme.md
+++ b/mcp-server/Readme.md
@@ -7,8 +7,9 @@ This is deployed at `https://todo-mcp.auth101.dev`.
 
 ## Instructions on How to Setup Auth0
 
-1. Enable Dynamic Client Registration 
-2. 
+1. Enable Dynamic Client Registration
+2. Create an API in your Auth0 account, and set up the TODO scopes (`read:todos`, `write:todos`, `delete:todos`)
+3. Enable a connection to be a "domain wide" connection (see https://auth0.com/docs/authenticate/identity-providers/promote-connections-to-domain-level) Without this, dynamically registred clients won't have any ability to login
 
 ## Acknowledgements and Thanks
 

--- a/mcp-server/prisma/schema.prisma
+++ b/mcp-server/prisma/schema.prisma
@@ -8,14 +8,14 @@ generator client {
   provider = "prisma-client-js"
 }
 
-datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
-}
 // datasource db {
-//   provider = "sqlite"
-//   url      = "file:./dev.db"
-// }
+//   provider = "postgresql"
+//   url      = env("DATABASE_URL")
+//}
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
 
 model User {
   id    String   @id @default(cuid())
@@ -26,7 +26,7 @@ model Todo {
   id          String   @id @default(cuid())
   title       String
   description String?
-  tags        String[]
+  tags        String
   completed   Boolean  @default(false)
   createdAt   DateTime @default(now())
   userId      String

--- a/mcp-server/src/session-storage.ts
+++ b/mcp-server/src/session-storage.ts
@@ -1,0 +1,17 @@
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+
+export class Sessions {
+  private sessions = new Map<string, SSEServerTransport>();
+
+  public add(sessionId: string, transport: SSEServerTransport): void {
+    this.sessions.set(sessionId, transport);
+  }
+
+  public get(sessionId: string): SSEServerTransport | undefined {
+    return this.sessions.get(sessionId);
+  }
+
+  public remove(sessionId: string): boolean {
+    return this.sessions.delete(sessionId);
+  }
+}

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -7,11 +7,7 @@ const prisma = new PrismaClient();
 export const createTodoSchema = {
   title: z.string().describe("Title for the Todo"),
   description: z.string().describe("The task to perform").optional(),
-  tags: z
-    .array(
-      z.string().describe("A hashtag associated with it like #job #personal")
-    )
-    .optional(),
+  tags: z.string().describe("A hashtag associated with it like #job #personal").optional(),
 } as const;
 
 export const createTodoTool = withAuthz<typeof createTodoSchema>(
@@ -23,7 +19,7 @@ export const createTodoTool = withAuthz<typeof createTodoSchema>(
       data: {
         title,
         description,
-        tags: tags ?? [],
+        tags: tags ?? "",
         user: {
           connectOrCreate: {
             create: {
@@ -51,8 +47,6 @@ export const searchTodoTool = withAuthz(
   async ({ search, tags }, { user }) => {
     console.info("Searching todos");
 
-    const tagArray = tags ? tags.split(",") : [];
-
     const todos = await prisma.todo.findMany({
       where: {
         userId: user.sub,
@@ -65,10 +59,11 @@ export const searchTodoTool = withAuthz(
                 ],
               }
             : {},
-          tagArray.length
+          tags
             ? {
                 tags: {
-                  hasSome: tagArray,
+                  contains: tags,
+                  mode: "insensitive"
                 },
               }
             : {},
@@ -87,7 +82,7 @@ export const updateTodoSchema = {
   id: z.string().describe("ID of the Todo to update"),
   title: z.string().describe("Updated title").optional(),
   description: z.string().describe("Updated task").optional(),
-  tags: z.array(z.string()).describe("Updated tags").optional(),
+  tags: z.string().describe("Updated tags").optional(),
   completed: z.boolean().describe("Mark as complete or not").optional(),
 } as const;
 


### PR DESCRIPTION
hey, here are the tweaks I needed to make to this run locally, and with the Anthropic API. Mostly just an FYI in case you find it useful / others want to run it locally.

Tweaks were:
* Anthropic in ai-sdk + model
* (optional) clear up error message on mismatched resource URLs
* Additional details on Auth0 steps (domain connection was most time consuming speed bump)
* Unignore session-storage (not sure what the original intent for ignoring that)
* Switch to sqlite + make some of the DB schema more sqlite-friendly (tags: String[] -> String)


Some other things I'd like to demo:
* Dynamic client registration requirements avoiding the confused deputy problem (think this is mitigated, but want to verify)
* The backing 3rd party flow (might be #4 ?)
* Using a demo AS + co-located AS instead of Auth0 (happy this is possible with Auth0, but want a standalone demo to test the spec)